### PR TITLE
Update gpt2_bpe_utils.py

### DIFF
--- a/fairseq/data/encoders/gpt2_bpe_utils.py
+++ b/fairseq/data/encoders/gpt2_bpe_utils.py
@@ -106,6 +106,7 @@ class Encoder:
     def encode(self, text):
         bpe_tokens = []
         for token in self.re.findall(self.pat, text):
+            token = token.lstrip()
             token = ''.join(self.byte_encoder[b] for b in token.encode('utf-8'))
             bpe_tokens.extend(self.encoder[bpe_token] for bpe_token in self.bpe(token).split(' '))
         return bpe_tokens


### PR DESCRIPTION
Basically, the tokens still have spacing, so the utf8 conversion will get messed up.

The simple fix is to get rid of the spacing.